### PR TITLE
cargo: Use stable `automerge 0.2` where our `git` dependency was merged

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,7 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-automerge = { git = "https://github.com/automerge/automerge-rs", rev = "6bbed76" }
+automerge = "0.2"
 serde = "1"
 thiserror = "1.0.32"


### PR DESCRIPTION
The `uuid` dependency upgrade landed, which is available in `rust/ automerge@0.2.0` tags and up: https://github.com/automerge/automerge/commit/6bbed76
