### PR TITLE
de: Generalize `Deserialize` implementation to use `ReadDoc`

### DIFF
--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -1,37 +1,37 @@
 use super::{Deserializer as ValueDeserializer, Error};
 use automerge::{
     iter::{MapRange, MapRangeItem},
-    Automerge, ObjId, ReadDoc as _, Value,
+    ObjId, ReadDoc, Value,
 };
 use serde::de::{self, IntoDeserializer};
 use std::ops::RangeFull;
 
-pub struct MapDeserializer<'a> {
-    doc: &'a Automerge,
+pub struct MapDeserializer<'a, Rx: ReadDoc> {
+    doc: &'a Rx,
     values: MapRange<'a, RangeFull>,
     current: Option<(Value<'a>, ObjId)>,
 }
 
-impl<'a> MapDeserializer<'a> {
-    pub fn new(doc: &'a Automerge, id: ObjId) -> Self {
+impl<'a, Rx: ReadDoc> MapDeserializer<'a, Rx> {
+    pub fn new(doc: &'a Rx, id: ObjId) -> Self {
         Self {
             doc,
             values: doc.map_range(id, ..),
             current: None,
         }
     }
-    pub fn new_root(doc: &'a Automerge) -> Self {
+    pub fn new_root(doc: &'a Rx) -> Self {
         Self::new(doc, ObjId::Root)
     }
 }
 
-impl<'a> From<&'a Automerge> for MapDeserializer<'a> {
-    fn from(doc: &'a Automerge) -> Self {
+impl<'a, Rx: ReadDoc> From<&'a Rx> for MapDeserializer<'a, Rx> {
+    fn from(doc: &'a Rx) -> Self {
         Self::new_root(doc)
     }
 }
 
-impl<'de, 'a> de::MapAccess<'de> for MapDeserializer<'a> {
+impl<'de, 'a, Rx: ReadDoc> de::MapAccess<'de> for MapDeserializer<'a, Rx> {
     type Error = Error;
 
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>

--- a/src/de/seq.rs
+++ b/src/de/seq.rs
@@ -1,18 +1,18 @@
 use super::{Deserializer as ValueDeserializer, Error};
 use automerge::{
     iter::{ListRange, ListRangeItem},
-    Automerge, ObjId, ReadDoc as _,
+    ObjId, ReadDoc,
 };
 use serde::de::{self};
 use std::ops::RangeFull;
 
-pub struct SeqDeserializer<'a> {
-    doc: &'a Automerge,
+pub struct SeqDeserializer<'a, Rx: ReadDoc> {
+    doc: &'a Rx,
     values: ListRange<'a, RangeFull>,
 }
 
-impl<'a> SeqDeserializer<'a> {
-    pub fn new(doc: &'a Automerge, id: ObjId) -> Self {
+impl<'a, Rx: ReadDoc> SeqDeserializer<'a, Rx> {
+    pub fn new(doc: &'a Rx, id: ObjId) -> Self {
         Self {
             doc,
             values: doc.list_range(id, ..),
@@ -20,7 +20,7 @@ impl<'a> SeqDeserializer<'a> {
     }
 }
 
-impl<'de, 'a> de::SeqAccess<'de> for SeqDeserializer<'a> {
+impl<'de, 'a, Rx: ReadDoc> de::SeqAccess<'de> for SeqDeserializer<'a, Rx> {
     type Error = Error;
 
     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>


### PR DESCRIPTION
While being tasked to use `AutoCommit` in our `automerge 0.5` upgrade (because this functionality used/appeared to be built in to `Automerge` on `automerge 0.2`), the serializer works naturally because it is implemented for the generic `Transactable` but deserializing is only implemented for `Automerge`.

Instead, implement the deserializer for `trait ReadDoc` so that both `Automerge` and `AutoCommit` can be used.

---

Note again that our efforts here might be futile/useless since the `automerge` repo also provides Serde support.
